### PR TITLE
Revert "Use locale string for last updated"

### DIFF
--- a/src/services/index.tsx
+++ b/src/services/index.tsx
@@ -43,7 +43,7 @@ const ServicesSection: NextPage = () => {
                     </div>
                     <div>
                         <p className="text-xs text-gray-400">Last updated</p>
-                        <p className="text-xs text-gray-400 text-end ">{new Date(systemStatus?.datetime).toLocaleString()}</p>
+                        <p className="text-xs text-gray-400 text-end ">{systemStatus?.datetime}</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Reverts slaclab/s3df-status-display#1

Will test original code with updated Next.js build action to make sure it works, then re-apply this patch.